### PR TITLE
Fix loadModel() in memdb

### DIFF
--- a/packages/platform/src/__tests__/memdb.test.ts
+++ b/packages/platform/src/__tests__/memdb.test.ts
@@ -254,21 +254,6 @@ describe('memdb', () => {
     })
   })
 
-  it('should load model', () => {
-    const doc1 = memdb.createDocument(test.class.DomainDoc, {})
-    const doc2 = memdb.createDocument(test.class.DomainDoc, {})
-    const doc3 = memdb.createDocument(test.class.DomainDoc, {})
-
-    memdb.loadModel([doc1, doc2, doc3])
-    expect(memdb.get(doc1._id)).toBe(doc1)
-    expect(memdb.get(doc2._id)).toBe(doc2)
-    expect(memdb.get(doc3._id)).toBe(doc3)
-  })
-
-  it('should fail to create transaction', () => {
-    expect(() => memdb.tx()).toThrowError('memdb is read only')
-  })
-
   it('should find all classes', () => {
     return memdb.find(test.class.Class, {}).then(docs => {
       expect(docs).toEqual(expectedMemdbContents)
@@ -314,5 +299,20 @@ describe('memdb', () => {
       expect(docs.length).toBe(3)
       expect(docs).toEqual([domainDoc, mixinDoc, mixinDoc2])
     })
+  })
+
+  it('should load model', () => {
+    const doc1 = memdb.createDocument(test.class.DomainDoc, {})
+    const doc2 = memdb.createDocument(test.class.DomainDoc, {})
+    const doc3 = memdb.createDocument(test.class.DomainDoc, {})
+
+    memdb.loadModel([doc1, doc2, doc3])
+    expect(memdb.get(doc1._id)).toBe(doc1)
+    expect(memdb.get(doc2._id)).toBe(doc2)
+    expect(memdb.get(doc3._id)).toBe(doc3)
+  })
+
+  it('should fail to create transaction', () => {
+    expect(() => memdb.tx()).toThrowError('memdb is read only')
   })
 })

--- a/packages/platform/src/memdb.ts
+++ b/packages/platform/src/memdb.ts
@@ -192,10 +192,8 @@ export class MemDb {
 
   loadModel (model: Doc[]) {
     for (const doc of model) {
-      this.set(doc)
+      this.add(doc)
     }
-    // if (this.byClass === null) { this.byClass = new Map<Ref<ClassLayout>, Doc[]>() }
-    // for (const doc of model) { this.index(doc) }
   }
 
   // Q U E R Y


### PR DESCRIPTION
Call of this method doesn' break the internal index anymore if called not on the start phase of the application.