### PR TITLE
Force update all caches after object creation

### DIFF
--- a/plugins/platform-core/src/plugin.ts
+++ b/plugins/platform-core/src/plugin.ts
@@ -114,7 +114,20 @@ export default async (platform: Platform): Promise<CoreService> => {
       object: doc
     }
 
-    return Promise.all([coreProtocol.tx(tx), txProcessor.process(tx)])
+    const createTx = new Promise((resolve, reject) => {
+      coreProtocol.tx(tx).then(result => {
+
+        // update caches when the object has been successfully created
+        qModel.refreshAll()
+        qTitles.refreshAll()
+        qGraph.refreshAll()
+        qCache.refreshAll()
+
+        resolve(result)
+      }).catch(err => reject(err))
+    })
+
+    return Promise.all([createTx, txProcessor.process(tx)])
   }
 
   function createVDoc<T extends VDoc> (vdoc: T): Promise<void> {

--- a/plugins/platform-core/src/queries.ts
+++ b/plugins/platform-core/src/queries.ts
@@ -35,7 +35,7 @@ export class QueriableStorage implements Domain {
     this.proxy = store
   }
 
-  private refreshAll () {
+  refreshAll () {
     this.queries.forEach(q => this.refresh(q))
   }
 


### PR DESCRIPTION
Otherwise, caches could be left in a non-updated state.

Signed-off-by: Roman Kuskov <roman.kuskov@gmail.com>