### PR TITLE
Remove strike & underline from styles

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -60,6 +60,7 @@
     </codeStyleSettings>
     <codeStyleSettings language="TypeScript">
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
       <option name="ALIGN_MULTILINE_FOR" value="false" />
       <option name="SPACE_BEFORE_METHOD_PARENTHESES" value="true" />

--- a/packages/sparkling-rich/src/EditorContent.svelte
+++ b/packages/sparkling-rich/src/EditorContent.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script lang='ts'>
   import { MessageNode } from '@anticrm/core'
   import { DOMParser, Fragment, Slice, Mark, MarkType } from 'prosemirror-model'
 
@@ -49,11 +49,11 @@
 
   let isEmpty: boolean = true
 
-  function checkEmpty(value: string): boolean {
+  function checkEmpty (value: string): boolean {
     return value.length === 0 || value === '<p><br></p>' || value === '<p></p>'
   }
 
-  function findCompletion(
+  function findCompletion (
     sel: any
   ): { completionWord: string; completionEnd: string } {
     var completionWord = ''
@@ -81,12 +81,18 @@
     if (sel.$from.nodeAfter != null) {
       completionEnd = sel.$from.nodeAfter.textContent
     }
-    return { completionWord, completionEnd }
+    return {
+      completionWord,
+      completionEnd
+    }
   }
 
-  function emitStyleEvent() {
+  function emitStyleEvent () {
     let sel = view.state.selection
-    var { completionWord, completionEnd } = findCompletion(sel)
+    var {
+      completionWord,
+      completionEnd
+    } = findCompletion(sel)
 
     let posAtWindow = view.coordsAtPos(sel.from - completionWord.length)
 
@@ -109,8 +115,6 @@
 
     let isBold = schema.marks.strong.isInSet(marks) != null
     let isItalic = schema.marks.em.isInSet(marks) != null
-    let isStrike = schema.marks.strike.isInSet(marks) != null
-    let isUnderline = schema.marks.underline.isInSet(marks) != null
     isEmpty = checkEmpty(innerDOMValue)
     let evt = {
       isEmpty: isEmpty,
@@ -118,10 +122,6 @@
       isBoldEnabled: Commands.toggleStrong(view.state),
       italic: isItalic,
       isItalicEnabled: Commands.toggleItalic(view.state),
-      strike: isStrike,
-      isStrikeEnabled: Commands.toggleStrike(view.state),
-      underline: isUnderline,
-      isUnderlineEnabled: Commands.toggleUnderline(view.state),
       cursor: {
         left: cursor.left,
         top: cursor.top,
@@ -130,19 +130,29 @@
       },
       completionWord,
       completionEnd,
-      selection: { from: sel.from, to: sel.to },
+      selection: {
+        from: sel.from,
+        to: sel.to
+      },
       inputHeight
     } as EditorContentEvent
     dispatch('styleEvent', evt)
   }
 
-  function createState(doc: MessageNode): EditorState {
+  function createState (doc: MessageNode): EditorState {
     return EditorState.fromJSON(
       {
         schema,
         plugins: [history(), buildInputRules(), keymap(buildKeymap())]
       },
-      { doc: doc, selection: { type: 'text', head: 0, anchor: 0 } }
+      {
+        doc: doc,
+        selection: {
+          type: 'text',
+          head: 0,
+          anchor: 0
+        }
+      }
     )
   }
 
@@ -154,7 +164,7 @@
   state = createState(content)
   view = new EditorView(rootElement, {
     state,
-    dispatchTransaction(transaction) {
+    dispatchTransaction (transaction) {
       let newState = view.state.apply(transaction)
 
       // Check and update triggers to update content.
@@ -181,7 +191,7 @@
     root.appendChild(rootElement)
   })
 
-  function updateValue(content: MessageNode) {
+  function updateValue (content: MessageNode) {
     if (JSON.stringify(content) != JSON.stringify(view.state.toJSON().doc)) {
       let newState = createState(content)
 
@@ -191,14 +201,14 @@
     }
   }
 
-  export function insert(text: string, from: number, to: number) {
+  export function insert (text: string, from: number, to: number) {
     const t = view.state.tr.insertText(text, from, to)
     const st = view.state.apply(t)
     view.updateState(st)
     emitStyleEvent()
   }
 
-  export function insertMark(
+  export function insertMark (
     text: string,
     from: number,
     to: number,
@@ -214,52 +224,49 @@
     view.updateState(st)
     emitStyleEvent()
   }
+
   // Some operations
-  export function toggleBold() {
+  export function toggleBold () {
     Commands.toggleStrong(view.state, view.dispatch)
     view.focus()
   }
-  export function toggleItalic() {
+
+  export function toggleItalic () {
     Commands.toggleItalic(view.state, view.dispatch)
     view.focus()
   }
-  export function toggleStrike() {
-    Commands.toggleStrike(view.state, view.dispatch)
-    view.focus()
-  }
-  export function toggleUnderline() {
-    Commands.toggleUnderline(view.state, view.dispatch)
-    view.focus()
-  }
-  export function toggleUnOrderedList() {
+
+  export function toggleUnOrderedList () {
     Commands.toggleUnOrdered(view.state, view.dispatch)
     view.focus()
   }
-  export function toggleOrderedList() {
+
+  export function toggleOrderedList () {
     Commands.toggleOrdered(view.state, view.dispatch)
     view.focus()
   }
-  export function focus() {
+
+  export function focus () {
     view.focus()
   }
 </script>
 
 <div
-  class="edit-box"
-  bind:this="{root}"
-  bind:clientHeight="{inputHeight}"
+  class='edit-box'
+  bind:this='{root}'
+  bind:clientHeight='{inputHeight}'
 ></div>
 <div
-  class="hover-message"
-  style="{`top:${-1 * inputHeight}px;` +  //
+  class='hover-message'
+  style='{`top:${-1 * inputHeight}px;` +  //
     `margin-bottom:${-1 * inputHeight}px;` +  //
-    `height:${inputHeight}px`}"
+    `height:${inputHeight}px`}'
 >
   {#if isEmpty}{hoverMessage}{/if}
 </div>
 <slot />
 
-<style lang="scss">
+<style lang='scss'>
   :global {
     .ProseMirror {
       position: relative;
@@ -268,7 +275,7 @@
     .ProseMirror {
       word-wrap: break-word;
       white-space: pre-wrap;
-      white-space: break-spaces;
+      //white-space: break-spaces;
       -webkit-font-variant-ligatures: none;
       font-variant-ligatures: none;
       font-feature-settings: 'liga' 0; /* the above doesn't seem to work in Edge */
@@ -285,9 +292,11 @@
     .ProseMirror-hideselection *::selection {
       background: transparent;
     }
+
     .ProseMirror-hideselection *::-moz-selection {
       background: transparent;
     }
+
     .ProseMirror-hideselection {
       caret-color: transparent;
     }
@@ -324,15 +333,18 @@
     :global {
       div {
         outline: none;
+
         p {
           margin: 5px;
         }
       }
     }
   }
+
   .edit-box:focus {
     outline: none;
   }
+
   .hover-message {
     position: relative;
     top: 0px;

--- a/packages/sparkling-rich/src/index.ts
+++ b/packages/sparkling-rich/src/index.ts
@@ -21,8 +21,6 @@ export interface EditorContentEvent {
     isEmpty: boolean
     bold: boolean
     italic: boolean
-    strike: boolean
-    underline: boolean
     cursor: { left: number; right: number; top: number; bottom: number }
     completionWord: string
     completionEnd: string

--- a/packages/sparkling-rich/src/internal/schema.ts
+++ b/packages/sparkling-rich/src/internal/schema.ts
@@ -142,8 +142,8 @@ function add (obj: any, props: any): any {
 const emDOM = ['em', 0]
 const strongDOM = ['strong', 0]
 const codeDOM = ['code', 0]
-const strikeDOM = ['s', 0]
-const underlineDOM = ['u', 0]
+// const strikeDOM = ['s', 0]
+// const underlineDOM = ['u', 0]
 
 // :: Object [Specs](#model.MarkSpec) for the marks in the schema.
 export const marks: MarkSpec = {
@@ -179,22 +179,6 @@ export const marks: MarkSpec = {
     parseDOM: [{ tag: 'i' }, { tag: 'em' }, { style: 'font-style=italic' }],
     toDOM () {
       return emDOM
-    }
-  },
-  // :: MarkSpec An emphasis mark. Rendered as an `<em>` element.
-  // Has parse rules that also match `<i>` and `font-style: italic`.
-  strike: {
-    parseDOM: [{ tag: 's' }],
-    toDOM () {
-      return strikeDOM
-    }
-  },
-  // :: MarkSpec An emphasis mark. Rendered as an `<em>` element.
-  // Has parse rules that also match `<i>` and `font-style: italic`.
-  underline: {
-    parseDOM: [{ tag: 'u' }],
-    toDOM () {
-      return underlineDOM
     }
   },
 

--- a/plugins/presentation/src/components/refinput/CompletionPopup.svelte
+++ b/plugins/presentation/src/components/refinput/CompletionPopup.svelte
@@ -2,7 +2,7 @@
   import Icon from '@anticrm/platform-ui/src/components/Icon.svelte'
 
   import ui from '@anticrm/platform-ui'
-  import { Class, Ref } from '@anticrm/model'
+  import { Class, Ref } from '@anticrm/core'
   import ScrollView from '@anticrm/sparkling-controls/src/ScrollView.svelte'
 
   import { createEventDispatcher, onMount } from 'svelte'

--- a/plugins/presentation/src/components/refinput/ReferenceInput.svelte
+++ b/plugins/presentation/src/components/refinput/ReferenceInput.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Property } from '@anticrm/model'
+  import { Property } from '@anticrm/core'
   import { MessageNode, newMessageDocument } from '@anticrm/core'
   import { getCoreService } from '../../utils'
 
@@ -56,8 +56,6 @@
     cursor: { left: 0, top: 0, bottom: 0, right: 0 },
     bold: false,
     italic: false,
-    strike: false,
-    underline: false,
     completionWord: '',
     selection: { from: 0, to: 0 },
     completionEnd: '',
@@ -366,15 +364,6 @@
             on:click={() => htmlEditor.toggleItalic()}
             selected={styleState.italic}>
             <Icon icon={presentation.icon.brdItalic} clazz="icon-brd" />
-          </ToolbarButton>
-          <ToolbarButton style="padding:0; width:24px; height:24px"
-            on:click={() => htmlEditor.toggleUnderline()}
-            selected={styleState.underline}>
-            <Icon icon={presentation.icon.brdUnder} clazz="icon-brd" />
-          </ToolbarButton>
-          <ToolbarButton style="padding:0; width:24px; height:24px"
-            on:click={() => htmlEditor.toggleStrike()} selected={styleState.strike}>
-            <Icon icon={presentation.icon.brdStrike} clazz="icon-brd" />
           </ToolbarButton>
           <div class="tSeparator" />
           <ToolbarButton style="padding:0; width:24px; height:24px">


### PR DESCRIPTION
Remove strike & underline since they are not supported by markdown persistence.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>