### PR TITLE
Fix some errors and warnings in browser console

### DIFF
--- a/dev/storybook/src/stories/sparkling-controls/ComboBox.svelte
+++ b/dev/storybook/src/stories/sparkling-controls/ComboBox.svelte
@@ -33,9 +33,9 @@
     let pathDrop: boolean = false
     let pathItems: boolean = false
     event.path.find((el) => {
-      if (el.className === comboRoot.className) pathRoot = true
-      if (el.className === comboDrop.className) pathDrop = true
-      if (el.className === comboItems.className) pathItems = true
+      if (el.className === comboRoot?.className) pathRoot = true
+      if (el.className === comboDrop?.className) pathDrop = true
+      if (el.className === comboItems?.className) pathItems = true
     })
     if (pathRoot && !pathDrop) {
       if (comboHidden) showCombo()

--- a/plugins/chunter/src/components/internal/ActivityItem.svelte
+++ b/plugins/chunter/src/components/internal/ActivityItem.svelte
@@ -93,7 +93,7 @@
 </style>
 
 <div class='activity-item'>
-  <img class='avatar' src={avatar} />
+  <img class='avatar' src={avatar} alt='avatar'/>
   <div class='details'>
     <b>{user ? user.name : ''}</b>
     <span>15:23</span>

--- a/plugins/chunter/src/components/internal/ActivityView.svelte
+++ b/plugins/chunter/src/components/internal/ActivityView.svelte
@@ -53,12 +53,6 @@
       display: flex;
       align-items: center;
     }
-
-    .container {
-      width: 100%;
-      height: 100%;
-      margin: 2em;
-    }
   }
 </style>
 

--- a/plugins/guidebook/src/components/internal/ReferenceInput.svelte
+++ b/plugins/guidebook/src/components/internal/ReferenceInput.svelte
@@ -15,10 +15,6 @@
 </script>
 
 <style lang="scss">
-  .toolbar_table {
-    width: 100%;
-    border: 1px solid white;
-  }
   .preview-pane {
     margin: 10px;
     background-color: hsl(210, 25%, 40%);

--- a/plugins/guidebook/src/components/internal/toolbar.svelte
+++ b/plugins/guidebook/src/components/internal/toolbar.svelte
@@ -120,10 +120,6 @@
 </PageBlock>
 
 <style lang="scss">
-  .toolbar_table {
-    width: 100%;
-    border: 1px solid white;
-  }
   .preview-pane {
     margin: 10px;
     background-color: hsl(210, 25%, 40%);

--- a/plugins/platform-ui/src/components/UserBox.svelte
+++ b/plugins/platform-ui/src/components/UserBox.svelte
@@ -33,9 +33,9 @@
     let pathItems: boolean = false
     var path = event['path'] || (event.composedPath && event.composedPath())
     path.find((el) => {
-      if (el.className === comboRoot.className) pathRoot = true
-      if (el.className === comboDrop.className) pathDrop = true
-      if (el.className === comboItems.className) pathItems = true
+      if (el.className === comboRoot?.className) pathRoot = true
+      if (el.className === comboDrop?.className) pathDrop = true
+      if (el.className === comboItems?.className) pathItems = true
     })
     if (pathRoot && !pathDrop) {
       if (comboHidden) {

--- a/plugins/workbench/src/components/internal/Application.svelte
+++ b/plugins/workbench/src/components/internal/Application.svelte
@@ -152,17 +152,6 @@
       align-items: center;
     }
 
-    .table {
-      margin: 1em;
-      flex-grow: 1;
-    }
-
-    .details {
-      border-top: 1px solid var(--theme-bg-accent-color);
-      padding: 1em;
-      //max-height: 400px;
-    }
-
     .presentation {
       display: flex;
       flex-direction: row-reverse;

--- a/plugins/workbench/src/components/internal/DefaultPerspective.svelte
+++ b/plugins/workbench/src/components/internal/DefaultPerspective.svelte
@@ -111,10 +111,6 @@
       border-bottom: solid 1px var(--theme-bg-accent-color);
       border-right: solid 1px var(--theme-bg-accent-color);
 
-      .icon {
-        padding: 1em;
-      }
-
       &.current-app {
         background-color: var(--theme-bg-color);
         border-right: solid 1px var(--theme-bg-color);


### PR DESCRIPTION
Signed-off-by: Artyom Savchenko artem.savchenko@xored.com

Fix errors:
```
UserBox.svelte:33 Uncaught TypeError: Cannot read property 'className' of null
    at UserBox.svelte:33
    at Array.find (<anonymous>)
    at toggleCombo (UserBox.svelte:32)
```
Fix warnings:
```
client:135 /Users/user/github/platform/plugins/chunter/src/components/internal/ActivityItem.svelte
Module Warning (from ./node_modules/svelte-loader/index.js):
A11y: <img> element should have an alt attribute (79:2)
client:135 /Users/user/github/platform/plugins/workbench/src/components/internal/DefaultPerspective.svelte
Module Warning (from ./node_modules/svelte-loader/index.js):
Unused CSS selector "nav .app-icon .icon" (104:0)
```