### PR TITLE
Fix table display with long strings

### DIFF
--- a/plugins/presentation/src/components/internal/Table.svelte
+++ b/plugins/presentation/src/components/internal/Table.svelte
@@ -24,6 +24,7 @@
   export let _class: Ref<Class<Doc>>
   export let space: Ref<Space>
   export let editable: boolean = true
+  export let columnMaxWidth: number = 300
 
   const dispatch = createEventDispatcher()
 
@@ -121,7 +122,9 @@
         {#each attributes as attr (attr.key)}
           <div class="td">
             {#if attr.presenter}
-              <Presenter is={attr.presenter} value={object[attr.key] || '' } attribute={attr} {editable} />
+              <div style={ (columnMaxWidth) ? 'max-width:' + columnMaxWidth + 'px' : '' }>
+                <Presenter is={attr.presenter} value={object[attr.key] || '' } attribute={attr} {editable} componentProps={{textWrap: !!columnMaxWidth}} />
+              </div>
             {:else}
               <span>{object[attr.key] || ''}</span>
             {/if}

--- a/plugins/presentation/src/components/internal/Table.svelte
+++ b/plugins/presentation/src/components/internal/Table.svelte
@@ -24,7 +24,6 @@
   export let _class: Ref<Class<Doc>>
   export let space: Ref<Space>
   export let editable: boolean = true
-  export let columnMaxWidth: number = 300
 
   const dispatch = createEventDispatcher()
 
@@ -122,9 +121,7 @@
         {#each attributes as attr (attr.key)}
           <div class="td">
             {#if attr.presenter}
-              <div style={ (columnMaxWidth) ? 'max-width:' + columnMaxWidth + 'px' : '' }>
-                <Presenter is={attr.presenter} value={object[attr.key] || '' } attribute={attr} {editable} componentProps={{textWrap: !!columnMaxWidth}} />
-              </div>
+              <Presenter is={attr.presenter} value={object[attr.key] || '' } attribute={attr} {editable} />
             {:else}
               <span>{object[attr.key] || ''}</span>
             {/if}

--- a/plugins/presentation/src/components/internal/presenters/Presenter.svelte
+++ b/plugins/presentation/src/components/internal/presenters/Presenter.svelte
@@ -26,6 +26,7 @@
   export let value: any
   export let attribute: AttrModel
   export let editable: boolean = true
+  export let componentProps: object = {}
 
   let component: Promise<any>
 
@@ -37,7 +38,7 @@
   {#await component }
     <Spinner />
   {:then ctor}
-    <svelte:component this={ctor} {attribute} {value} on:change />
+    <svelte:component this={ctor} {attribute} {value} {...componentProps} on:change />
   {:catch err}
     <Icon icon={ui.icon.Error} size="32" />
   {/await}

--- a/plugins/presentation/src/components/internal/presenters/Presenter.svelte
+++ b/plugins/presentation/src/components/internal/presenters/Presenter.svelte
@@ -26,7 +26,6 @@
   export let value: any
   export let attribute: AttrModel
   export let editable: boolean = true
-  export let componentProps: object = {}
 
   let component: Promise<any>
 
@@ -38,7 +37,7 @@
   {#await component }
     <Spinner />
   {:then ctor}
-    <svelte:component this={ctor} {attribute} {value} {...componentProps} on:change />
+    <svelte:component this={ctor} {attribute} {value} on:change />
   {:catch err}
     <Icon icon={ui.icon.Error} size="32" />
   {/await}

--- a/plugins/presentation/src/components/internal/presenters/Presenter.svelte
+++ b/plugins/presentation/src/components/internal/presenters/Presenter.svelte
@@ -26,6 +26,7 @@
   export let value: any
   export let attribute: AttrModel
   export let editable: boolean = true
+  export let maxWidth: number = 300
 
   let component: Promise<any>
 
@@ -37,7 +38,9 @@
   {#await component }
     <Spinner />
   {:then ctor}
-    <svelte:component this={ctor} {attribute} {value} on:change />
+    <div style={ 'max-width:' + maxWidth + 'px' }>
+      <svelte:component this={ctor} {attribute} {value} on:change />
+    </div>
   {:catch err}
     <Icon icon={ui.icon.Error} size="32" />
   {/await}

--- a/plugins/presentation/src/components/internal/presenters/value/CheckboxEditor.svelte
+++ b/plugins/presentation/src/components/internal/presenters/value/CheckboxEditor.svelte
@@ -19,10 +19,9 @@
 
   export let value: boolean
   export let attribute: AttrModel
-  export let maxWidth: number = 300
   export let editable: boolean = true
 
   $: readOnlyField = attribute && (attribute.type._class === CORE_CLASS_ARRAY_OF || attribute.type._class === CORE_CLASS_INSTANCE_OF)
 </script>
 
-<CheckBox bind:checked={value} placeholder={attribute.placeholder} {maxWidth} {editable} />
+<CheckBox bind:checked={value} placeholder={attribute.placeholder} {editable} />

--- a/plugins/presentation/src/components/internal/presenters/value/RefPresenter.svelte
+++ b/plugins/presentation/src/components/internal/presenters/value/RefPresenter.svelte
@@ -21,7 +21,6 @@
 
   export let value: Ref<Doc>
   export let attribute: AttrModel
-  export let maxWidth: number = 300
   export let editable: boolean
 
   let doc: Doc

--- a/plugins/presentation/src/components/internal/presenters/value/StringEditor.svelte
+++ b/plugins/presentation/src/components/internal/presenters/value/StringEditor.svelte
@@ -19,7 +19,6 @@
 
   export let value: string
   export let attribute: AttrModel
-  export let maxWidth: number = 300
   export let editable: boolean
 
   // Do not allow edit of arrays and instances by this string presenter.
@@ -35,15 +34,9 @@
 </style>
 
 {#if readOnlyField}
-  {#if maxWidth}
-    <div style={ 'max-width:' + maxWidth + 'px' }>
-      <div class="wrapped-text">
-        {value}
-      </div>
-    </div>
-  {:else}
+  <div class="wrapped-text">
     {value}
-  {/if}
+  </div>
 {:else}
-  <InlineEdit bind:value placeholder={attribute.placeholder || ""} {maxWidth} {editable} />
+  <InlineEdit bind:value placeholder={attribute.placeholder || ""} {editable} />
 {/if}

--- a/plugins/presentation/src/components/internal/presenters/value/StringEditor.svelte
+++ b/plugins/presentation/src/components/internal/presenters/value/StringEditor.svelte
@@ -36,9 +36,15 @@
 </style>
 
 {#if readOnlyField}
-  <div class:wrapped-text={textWrap}>
+  {#if maxWidth}
+    <div style={ 'max-width:' + maxWidth + 'px' }>
+      <div class="wrapped-text">
+        {value}
+      </div>
+    </div>
+  {:else}
     {value}
-  </div>
+  {/if}
 {:else}
   <InlineEdit bind:value placeholder={attribute.placeholder || ""} {maxWidth} {editable} />
 {/if}

--- a/plugins/presentation/src/components/internal/presenters/value/StringEditor.svelte
+++ b/plugins/presentation/src/components/internal/presenters/value/StringEditor.svelte
@@ -21,14 +21,24 @@
   export let attribute: AttrModel
   export let maxWidth: number = 300
   export let editable: boolean
+  export let textWrap: boolean
 
   // Do not allow edit of arrays and instances by this string presenter.
   $: readOnlyField = !editable || (attribute && (attribute.type._class === CORE_CLASS_ARRAY_OF || attribute.type._class === CORE_CLASS_INSTANCE_OF))
 </script>
 
+<style lang="scss">
+  .wrapped-text {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    hyphens: auto;
+  }
+</style>
 
 {#if readOnlyField}
-  {value}
+  <div class:wrapped-text={textWrap}>
+    {value}
+  </div>
 {:else}
   <InlineEdit bind:value placeholder={attribute.placeholder || ""} {maxWidth} {editable} />
 {/if}

--- a/plugins/presentation/src/components/internal/presenters/value/StringEditor.svelte
+++ b/plugins/presentation/src/components/internal/presenters/value/StringEditor.svelte
@@ -21,7 +21,6 @@
   export let attribute: AttrModel
   export let maxWidth: number = 300
   export let editable: boolean
-  export let textWrap: boolean
 
   // Do not allow edit of arrays and instances by this string presenter.
   $: readOnlyField = !editable || (attribute && (attribute.type._class === CORE_CLASS_ARRAY_OF || attribute.type._class === CORE_CLASS_INSTANCE_OF))


### PR DESCRIPTION
Signed-off-by: Artyom Savchenko <artem.savchenko@xored.com>

Columns in table were stretched indefinitely when entering long strings:
![Screen Shot 2021-02-28 at 16 08 52](https://user-images.githubusercontent.com/79742701/109415286-67759780-79ea-11eb-972b-799d74c4f247.png)
I added support for max size and word wrap  in the table:
![Screen Shot 2021-02-28 at 17 11 29](https://user-images.githubusercontent.com/79742701/109415330-92f88200-79ea-11eb-97af-9156ce9e7fd2.png)
 