### PR TITLE
Short ID references

### DIFF
--- a/packages/domains/src/index.ts
+++ b/packages/domains/src/index.ts
@@ -130,8 +130,16 @@ export const REFERENCE_DOMAIN = 'references'
 export const TITLE_DOMAIN = 'title'
 export const CORE_CLASS_TITLE = 'class:core.Title' as Ref<Class<Title>>
 
+/**
+ * Define a title source, ShortId titles will be used to reference documents with short form.
+ */
+export enum TitleSource {
+  Title, ShortId
+}
+
 export interface Title extends Doc {
   _objectClass: Ref<Classifier<Doc>>
   _objectId: Ref<Doc>
   title: string | number
+  source: TitleSource
 }

--- a/packages/domains/src/indices/title.ts
+++ b/packages/domains/src/indices/title.ts
@@ -14,12 +14,11 @@
 //
 
 import {
-  AnyLayout,
-  Class, Classifier, Doc, DomainIndex, generateId, mixinKey, Model, Ref, Storage, Tx, TxContext
+  AnyLayout, Class, Classifier, Doc, DomainIndex, generateId, mixinKey, Model, Ref, Storage, Tx, TxContext
 } from '@anticrm/core'
 import {
   CORE_CLASS_CREATE_TX, CORE_CLASS_DELETE_TX, CORE_CLASS_PUSH_TX, CORE_CLASS_TITLE, CORE_CLASS_UPDATE_TX,
-  CORE_MIXIN_SHORTID, CreateTx, DeleteTx, Title, UpdateTx
+  CORE_MIXIN_SHORTID, CreateTx, DeleteTx, Title, TitleSource, UpdateTx
 } from '..'
 
 const NULL = '<null>'
@@ -79,6 +78,7 @@ export class TitleIndex implements DomainIndex {
       _id: this.getPrimaryID(create._objectId), // Use same object Id, so we will be able to update it in case of title change.
       _objectClass: create._objectClass,
       _objectId: create._objectId,
+      source: TitleSource.Title,
       title
     }
 
@@ -110,7 +110,8 @@ export class TitleIndex implements DomainIndex {
         _id: generateId() as Ref<Title>,
         _objectClass: _class,
         _objectId: _id,
-        title: shortId
+        title: shortId,
+        source: TitleSource.ShortId
       }
       await this.storage.store(ctx, doc)
     }

--- a/packages/model/src/__model__.ts
+++ b/packages/model/src/__model__.ts
@@ -17,7 +17,7 @@ import core, { ArrayOf$, Builder, Class$, InstanceOf$, Mixin$, Primary, Prop, Re
 
 import { Classifier, DateProperty, Doc, MODEL_DOMAIN, Ref, SPACE_DOMAIN, StringProperty, Type } from '@anticrm/core'
 
-import { Application, ShortID, Space, SpaceUser, Title, TITLE_DOMAIN, VDoc } from '@anticrm/domains'
+import { Application, ShortID, Space, SpaceUser, Title, TITLE_DOMAIN, TitleSource, VDoc } from '@anticrm/domains'
 
 import {
   TArrayOf, TAttribute, TClass, TClassifier, TDoc, TEmb, TIndexesClass, TMixin, TObj, TRefTo, TType
@@ -91,6 +91,7 @@ export class TTitle extends TDoc implements Title {
   @RefTo$(core.class.Class) _objectClass!: Ref<Classifier<Doc>>
   @RefTo$(core.class.Doc) _objectId!: Ref<Doc>
   @Prop() title!: string | number
+  @Prop() source!: TitleSource
 }
 
 export function model (S: Builder): void {

--- a/packages/text/src/index.ts
+++ b/packages/text/src/index.ts
@@ -223,7 +223,9 @@ export function serializeMessageMarkdown (node: MessageNode): string {
 
 export function parseMessageMarkdown (message: string): MessageNode {
   const parser = new MarkdownParser()
-  return parser.parse(message || '')
+  const result = parser.parse(message || '')
+  console.log('PARSE:', message, result)
+  return result
 }
 
 type NodeProcessor = (
@@ -815,7 +817,7 @@ class MarkdownParseState {
             type: MessageMarkType.reference,
             attrs: {
               id: url.hash.substring(1),
-              class: 'class:' + url.hostname
+              class: 'class:' + url.pathname.substring(2)
             }
           })
         }

--- a/plugins/platform-core/src/plugin.ts
+++ b/plugins/platform-core/src/plugin.ts
@@ -149,7 +149,11 @@ export default async (platform: Platform): Promise<CoreService> => {
       const q = query(newClass, newQuery)
       unsubscriber = q.subscribe(action)
     }
-    result(_class, _query)
+    try {
+      result(_class, _query)
+    } catch (ex) {
+      console.error(ex)
+    }
     return result
   }
 

--- a/plugins/platform-ui/src/location.ts
+++ b/plugins/platform-ui/src/location.ts
@@ -9,9 +9,9 @@ export function locationToUrl (location: PlatformLocation): string {
     const queryValue = Object.entries(location.query).map(e => {
       if (e[1]) {
         // Had value
-        return encodeURIComponent(e[0]) + '=' + encodeURIComponent(e[1])
+        return e[0] + '=' + e[1]
       } else {
-        return encodeURIComponent(e[0])
+        return e[0]
       }
     }).join('&')
     if (queryValue.length > 0) {
@@ -19,7 +19,7 @@ export function locationToUrl (location: PlatformLocation): string {
     }
   }
   if (location.fragment && location.fragment.length > 0) {
-    result += '#' + encodeURIComponent(location.fragment)
+    result += '#' + location.fragment
   }
 
   return result
@@ -43,10 +43,10 @@ export function parseQuery (query: string): Record<string, string | null> {
   const result: Record<string, string | null> = {}
   for (var i = 0; i < vars.length; i++) {
     const pair = vars[i].split('=')
-    const key = decodeURIComponent(pair[0])
+    const key = pair[0]
     if (key.length > 0) {
       if (pair.length > 1) {
-        const value = decodeURIComponent(pair[1])
+        const value = pair[1]
         result[key] = value
       } else {
         result[key] = null

--- a/plugins/platform-ui/src/plugin.ts
+++ b/plugins/platform-ui/src/plugin.ts
@@ -14,8 +14,8 @@
 //
 
 import type { Platform } from '@anticrm/platform'
-import type { AnySvelteComponent, Location, UIService } from '.'
-import ui from '.'
+import type { AnySvelteComponent, DocumentProvider, Location, UIService } from '.'
+import ui, { ApplicationRouter } from '.'
 
 import { derived, Readable, writable } from 'svelte/store'
 
@@ -26,6 +26,9 @@ import { store } from './stores'
 import Spinner from './components/internal/Spinner.svelte'
 import Icon from './components/Icon.svelte'
 import { locationToUrl, parseLocation } from './location'
+import { Router } from './routes'
+import { getContext, onDestroy, setContext } from 'svelte'
+import { Class, Doc, Ref } from '@anticrm/core'
 
 /*!
  * Anticrm Platform™ UI Plugin
@@ -94,13 +97,54 @@ export default async (platform: Platform): Promise<UIService> => {
     store.set({ is: undefined, props: {}, element: undefined })
   }
 
+  const CONTEXT_ROUTE_VALUE = 'routes.context'
+
+  function newRouter<T> (pattern: string, matcher: (match: T) => void, defaults: T | undefined = undefined): ApplicationRouter<T> {
+    const r = getContext(CONTEXT_ROUTE_VALUE) as Router<any>
+    const result = r ? r.newRouter<T>(pattern, defaults) : new Router<T>(pattern, r, defaults, navigate)
+    result.subscribe(matcher)
+    if (!r) {
+      // No parent, we need to subscribe for location changes.
+      uiService.subscribeLocation((loc) => {
+        result.update(loc)
+      }, onDestroy)
+    }
+    setContext(CONTEXT_ROUTE_VALUE, result)
+    return result
+  }
+
+  let documentProvider: DocumentProvider | undefined
+
+  function open (_class: Ref<Class<Doc>>, _objectId: Ref<Doc>): Promise<void> {
+    if (documentProvider) {
+      return documentProvider.open(_class, _objectId)
+    }
+    return Promise.reject(new Error('Document provder is not registred'))
+  }
+
+  function selection (): { _class: Ref<Class<Doc>>; _objectId: Ref<Doc> } | undefined {
+    if (documentProvider) {
+      return documentProvider.selection()
+    }
+    return undefined
+  }
+
+  function registerDocumentProvider (provider: DocumentProvider): void {
+    documentProvider = provider
+  }
+
   const uiService = {
     createApp,
     subscribeLocation,
     navigateJoin,
     navigate,
+    newRouter,
     showModal,
-    closeModal
+    closeModal,
+
+    open,
+    selection,
+    registerDocumentProvider
   } as UIService
 
   return uiService

--- a/plugins/platform-ui/src/routes.ts
+++ b/plugins/platform-ui/src/routes.ts
@@ -76,9 +76,9 @@ export class Router<T> implements ApplicationRouter<T> {
 
   private matched = false
 
-  private doNavigate: (newLoc: Location) => void
+  private doNavigate: ((newLoc: Location) => void) | undefined
 
-  constructor (pattern: string, parent: Router<any> | undefined = undefined, defaults: T | undefined, doNavigate: (newLoc: Location) => void) {
+  constructor (pattern: string, parent: Router<any> | undefined = undefined, defaults: T | undefined = undefined, doNavigate: ((newLoc: Location) => void) | undefined = undefined) {
     this.pattern = pattern
     this.parentRouter = parent
     if (defaults) {

--- a/plugins/presentation/src/components/MessageViewer.svelte
+++ b/plugins/presentation/src/components/MessageViewer.svelte
@@ -21,7 +21,11 @@
     messageContent
   } from '@anticrm/text'
 
+  import { getUIService } from '@anticrm/platform-ui'
+
   export let message: MessageNode
+
+  const uiService = getUIService()
 
   class Style {
     bold: boolean = false
@@ -44,7 +48,7 @@
 
   $: style = computedStyle(message.marks || [])
 
-  function computedStyle(marks: MessageMark[]): Style {
+  function computedStyle (marks: MessageMark[]): Style {
     let result = new Style()
     for (let mark of marks) {
       switch (mark.type) {
@@ -53,12 +57,6 @@
           break
         case MessageMarkType.em:
           result.italic = true
-          break
-        case MessageMarkType.underline:
-          result.underline = true
-          break
-        case MessageMarkType.strike:
-          result.strike = true
           break
         case MessageMarkType.reference:
           let rm: ReferenceMark = mark as ReferenceMark
@@ -84,16 +82,14 @@
     class="inline-block"
     class:bold="{style.bold}"
     class:italic="{style.italic}"
-    class:underline="{style.underline}"
-    class:strike="{style.strike}"
     class:resolved_reference="{style.reference.resolved}"
     class:unknown_reference="{style.reference.state && !style.reference.resolved}"
   >
     {#if style.reference.state}
       <!-- TODO: Add a proper click handler here-->
       <a
-        href="{'#click-me:' + style.reference._class + '/' + style.reference._id}"
-      >
+        href="#"
+        on:click={()=>{uiService.open(style.reference._class, style.reference._id )}}>
         {message.text || ''}
       </a>
     {:else}{message.text || ''}{/if}
@@ -133,18 +129,19 @@
     display: inline-block;
     white-space: pre;
   }
+
   .bold {
     font-weight: bold;
   }
+
   .italic {
     font-style: italic;
   }
-  .underline {
-    text-decoration: underline;
-  }
+
   .resolved_reference {
     color: lightblue;
   }
+
   .unknown_reference {
     color: grey;
   }

--- a/plugins/workbench/src/components/internal/DefaultPerspective.svelte
+++ b/plugins/workbench/src/components/internal/DefaultPerspective.svelte
@@ -13,10 +13,10 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import { Ref, Doc, Class } from '@anticrm/core'
+  import { Ref, Doc, Class, StringProperty, Property } from '@anticrm/core'
   import { onDestroy } from 'svelte'
   import { getUIService, _getCoreService } from '../../utils'
-  import { Space, VDoc, CORE_CLASS_SPACE } from '@anticrm/domains'
+  import { Space, VDoc, CORE_CLASS_SPACE, Title, CORE_CLASS_TITLE, TitleSource } from '@anticrm/domains'
   import ui, { Location, newRouter } from '@anticrm/platform-ui'
   import workbench, { WorkbenchApplication } from '../..'
 
@@ -52,7 +52,7 @@
   let applications: WorkbenchApplication[] = []
 
   let component: AnyComponent | undefined
-  let details: { _id: Ref<Doc>; _class: Ref<Class<Doc>> } | undefined
+  let details: { _objectId: Ref<Doc>; _class: Ref<Class<Doc>> } | undefined
 
   interface WorkbenchRouteInfo {
     space: string // A ref of space name
@@ -69,7 +69,7 @@
     } as WorkbenchRouteInfo
   }
 
-  const router = newRouter<WorkbenchRouteInfo>(':space/:app?_class#_id', (info) => {
+  const router = newRouter<WorkbenchRouteInfo>(':space/:app', (info) => {
     if (spaces.length > 0) {
       space = spaces.find((s) => (s._id === info.space as Ref<Space>) || s.spaceKey === info.space) || spaces[0]
     }
@@ -77,12 +77,64 @@
       application = applications.find((a) => (a._id === info.app || a.route === info.app || a.label === info.app)) || applications[0]
       component = application?.component
     }
-    if (info._id && info._class) {
-      details = { _id: info._id, _class: info._class }
+  }, routeDefaults())
+
+  interface DocumentMatcher {
+    _class: string | undefined
+    doc: string | undefined
+  }
+
+  const documentRouter = newRouter<DocumentMatcher>('?doc&_class', async (match) => {
+    // Parse browse and convert it to _class and objectId
+    if (match.doc) {
+      // Check find a title
+      const title = await coreService.findOne<Title>(CORE_CLASS_TITLE, {
+        title: match.doc as StringProperty,
+        source: TitleSource.ShortId as Property<TitleSource, number>
+      })
+      if (title) {
+        // So we had a title,
+        details = { _class: title._objectClass, _objectId: title._objectId }
+      } else {
+        // We failed to find a title, use as is
+        details = { _class: match._class as Ref<Class<Doc>>, _objectId: match.doc as Ref<Doc> }
+      }
     } else {
       details = undefined
     }
-  }, routeDefaults())
+  })
+
+  async function navigateDocument (_class: Ref<Class<Doc>>, _objectId: Ref<Doc>): Promise<void> {
+    if (!_class || !_objectId) {
+      documentRouter.navigate({ _class: undefined, doc: undefined })
+      return
+    }
+    // Find if object has a shortId.
+    const title = await coreService.findOne<Title>(CORE_CLASS_TITLE, {
+      _objectId: _objectId,
+      _objectClass: _class,
+      source: TitleSource.ShortId as Property<TitleSource, number>
+    })
+
+    if (title && title.title) {
+      // Navigate using shortId
+      documentRouter.navigate({ doc: `${title.title}`, _class: undefined })
+    } else {
+      // There is not short Id, we should navigate using a full _class and objectId.
+      documentRouter.navigate({ _class: _class, doc: _objectId })
+    }
+  }
+
+  uiService.registerDocumentProvider({
+    open: navigateDocument,
+    selection (): { _class: Ref<Class<Doc>>; _objectId: Ref<Doc> } | undefined {
+      return details
+    }
+  })
+
+  onDestroy(() => {
+    uiService.registerDocumentProvider(undefined)
+  })
 
   coreService.subscribe(CORE_CLASS_SPACE, {}, (docs) => {
     spaces = docs.filter((s) => getCurrentUserSpace(currentUser, s))
@@ -269,16 +321,14 @@
         is={component}
         {application}
         {space}
-        on:open={(e) => {
-          router.navigate({_class: e.detail._class, _id: e.detail._id})
-        }} />
+        on:open={(e) => navigateDocument(e.detail._class, e.detail._id)} />
     {/if}
   </div>
   {#if details}
     <Splitter {prevDiv} {nextDiv} minWidth="404" />
     <aside bind:this={nextDiv}>
       <ObjectForm {...details} title="Title"
-                  on:close={()=> {router.navigate({_class: undefined, _id: undefined})}} />
+                  on:close={()=> navigateDocument(undefined, undefined)} />
     </aside>
   {/if}
 </div>

--- a/plugins/workbench/src/components/internal/ObjectForm.svelte
+++ b/plugins/workbench/src/components/internal/ObjectForm.svelte
@@ -24,7 +24,7 @@
 
   let title: string
   export let _class: Ref<Class<Doc>>
-  export let _id: Ref<Doc>
+  export let _objectId: Ref<Doc>
 
   let object: Doc | undefined
   let counter = 0
@@ -33,13 +33,13 @@
 
   const coreService = _getCoreService()
 
-  queryUpdate = coreService.subscribe(_class, { _id }, (docs) => {
+  queryUpdate = coreService.subscribe(_class, { _id: _objectId }, (docs) => {
     object = docs.length > 0 ? docs[0] : undefined
   }, onDestroy)
 
   let component: AnyComponent
   $: {
-    queryUpdate(_class, { _id })
+    queryUpdate(_class, { _id: _objectId })
 
     getComponentExtension(_class, presentation.mixin.DetailForm).then((ext) => {
       if (component !== ext) {

--- a/plugins/workbench/src/components/internal/Workbench.svelte
+++ b/plugins/workbench/src/components/internal/Workbench.svelte
@@ -11,28 +11,34 @@
   //
   // See the License for the specific language governing permissions and
   // limitations under the License.
-  import { Doc, Ref } from '@anticrm/core'
-  import workbench, { Perspective } from '../..'
+  import workbench, { Perspective, WorkbenchApplication } from '../..'
   import { _getCoreService, getUIService } from '../../utils'
   import { onDestroy } from 'svelte'
 
   import Component from '@anticrm/platform-ui/src/components/Component.svelte'
   import Spotlight from './Spotlight.svelte'
   import { AnyComponent, newRouter } from '@anticrm/platform-ui'
+  import { Ref } from '@anticrm/core'
 
   const coreService = _getCoreService()
   const uiService = getUIService()
-
-  interface PerspectiveInfo {
-    perspective: string
-  }
 
   let perspectives: Perspective[] = []
   let component: AnyComponent | undefined
 
   let activePerspective: string
 
-  const router = newRouter<PerspectiveInfo>(':perspective', (info) => {
+  export interface PerspectiveReference {
+    perspective: string
+  }
+
+  export interface WorkbenchRouterReference {
+    space: string // A ref of space name
+    app: Ref<WorkbenchApplication>
+  }
+
+
+  const router = newRouter<PerspectiveReference>(':perspective', (info) => {
     activePerspective = info.perspective
 
     if (perspectives.length > 0 && activePerspective) {
@@ -41,16 +47,11 @@
     }
   }, { perspective: '#none' })
 
-  let perspectiveOkResolve: () => void
-  const perspectiveOk = new Promise((resolve) => {
-    perspectiveOkResolve = resolve
-  })
   coreService.subscribe(workbench.class.Perspective, {}, (p) => {
     perspectives = p
     if (perspectives.length > 0) {
       router.setDefaults({ perspective: perspectives[0].name })
     }
-    perspectiveOkResolve()
   }, onDestroy)
 
   function handleKeydown (ev: KeyboardEvent) {
@@ -62,11 +63,9 @@
 
 <div id="workbench">
   <main>
-    {#await perspectiveOk then ct}
-      {#if component}
-        <Component is="{component}" props={activePerspective} />
-      {/if}
-    {/await}
+    {#if component}
+      <Component is="{component}" props={activePerspective} />
+    {/if}
   </main>
 
 </div>


### PR DESCRIPTION
1. A referencing via short IDs.
2.  Fix markdown parser references
3. Make different between short-id and title in Title index.
4.  Move newRouter inside plugin code.
5. Remove redundant URI encoding for query parameters and fragment.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>