### PR TITLE
Live Query fixes and 93% coverage for them.

### DIFF
--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -1,22 +1,20 @@
 //
-// Copyright © 2020 Anticrm Platform Contributors.
-// 
+// Copyright © 2021 Anticrm Platform Contributors.
+//
 // Licensed under the Eclipse Public License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License. You may
 // obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// 
+//
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
 
-// For a detailed explanation regarding each configuration property, visit:
-// https://jestjs.io/docs/en/configuration.html
-
 module.exports = {
+  preset: 'ts-jest',
   coverageDirectory: 'coverage',
   testEnvironment: 'node',
   roots: [

--- a/packages/client/src/__test__/search.test.ts
+++ b/packages/client/src/__test__/search.test.ts
@@ -1,0 +1,278 @@
+//
+// Copyright © 2021 Anticrm Platform Contributors.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { Doc, DocumentQuery, DocumentValue, FindOptions, Model, SortingOrder, txContext } from '@anticrm/core'
+import { createSubtask, createTask, data, Task, TaskComment, taskIds } from '@anticrm/core/src/__tests__/tasks'
+import { txBuilder } from '@anticrm/domains'
+import { QueriableStorage } from '../queries'
+
+/* eslint-env jest */
+
+async function prepare (): Promise<{ model: Model, storage: QueriableStorage, docs: Doc[] }> {
+  const model = new Model('vdocs')
+  await model.loadModel(data)
+  const docs: Doc[] = []
+
+  for (let i = 0; i < 50; i++) {
+    const tt = createTask(`t${i}`, 30, `task ${i}`)
+    const c1: DocumentValue<TaskComment> = {
+      _id: `#${50 - i}`,
+      oldVersion: [],
+      message: `m-t${i}`,
+      author: '',
+      date: new Date()
+    }
+    tt.mainTask = createSubtask(`m-t${i}`, 40, [c1])
+    tt.tasks = [createSubtask(`st-t${i}`, 40, [c1])]
+
+    const t = model.createDocument<Task>(taskIds.class.Task, tt)
+
+    if (i % 3 === 0) {
+      t.rate = 33
+    } else if (i % 34 === 0) {
+      t.rate = 34
+    }
+    if (i % 4 === 0) {
+      t.lists = [i.toString()]
+    }
+    model.add(t)
+    docs.push(t)
+  }
+
+  const storage = new QueriableStorage(model, model, true)
+  return { model, storage, docs }
+}
+
+async function doQuery (storage: QueriableStorage, query: DocumentQuery<Task>, op: (docs: Task[]) => void, options?: FindOptions<Task>): Promise<void> {
+  const result = storage.query(taskIds.class.Task, query, options)
+  const p1: Promise<Task[]> = new Promise(resolve => {
+    result.subscribe((docs) => {
+      resolve(docs)
+      op(docs)
+    })
+  })
+  // Checks
+  const docs = await p1
+  expect(docs).toBeDefined()
+}
+
+describe('live queries', () => {
+  it('check store op', async () => {
+    /**
+     * Check if store will trigger live query update, and it will be one one update during store
+     */
+    const { model, storage } = await prepare()
+
+    let lastDocs: Doc[] = []
+    let ops = 0
+    await doQuery(storage, {}, (docs) => { lastDocs = docs; ops++ })
+    expect(lastDocs.length).toEqual(50)
+
+    await storage.store(txContext(), model.createDocument<Task>(taskIds.class.Task, createTask('EXTRA', 31, 'EXTRA')))
+
+    expect(lastDocs.length).toEqual(51)
+    expect(ops).toEqual(1 + 1)
+  })
+  it('check store limit', async () => {
+    /**
+     * Check if store will trigger live query update, Enable limit to 10 items and
+     * check it will be no updates.
+     */
+    const { model, storage } = await prepare()
+
+    let lastDocs: Doc[] = []
+    let ops = 0
+    await doQuery(storage, {}, (docs) => { lastDocs = docs; ops++ }, { limit: 10 })
+    expect(lastDocs.length).toEqual(10)
+
+    await storage.store(txContext(), model.createDocument<Task>(taskIds.class.Task, createTask('EXTRA', 31, 'EXTRA')))
+
+    expect(lastDocs.length).toEqual(10)
+    expect(ops).toEqual(1 + 1)
+  })
+  it('check remove limit', async () => {
+    /**
+      * Check if remove will trigger live query update, with limit to 10 items and
+      * check it will be 2 updates, since we need info from server.
+      */
+    const { storage } = await prepare()
+
+    let lastDocs: Doc[] = []
+    let ops = 0
+    await doQuery(storage, {}, (docs) => { lastDocs = docs; ops++ }, { limit: 10 })
+    expect(lastDocs.length).toEqual(10)
+
+    await storage.remove(txContext(), lastDocs[0]._class, lastDocs[0]._id)
+
+    expect(lastDocs.length).toEqual(10)
+    expect(ops).toEqual(1 + 2)
+  })
+  it('check update fit', async () => {
+    /**
+     * Check what update operation on object in query and will trigger
+     * live query update and no server refresh will happen
+     */
+    const { storage, docs: sourceDocs } = await prepare()
+
+    let lastDocs: Doc[] = []
+    let opdates = 0
+    await doQuery(storage, { rate: 33 }, (docs) => { lastDocs = docs; opdates++ })
+    expect(lastDocs.length).toEqual(17)
+
+    const op = txBuilder<Task>(taskIds.class.Task).set({ rate: 33 })
+
+    const d = sourceDocs[1]
+    await storage.update(txContext(), d._class, d._id, [op])
+
+    expect(opdates).toEqual(1 + 1) // We should have only two updates happening
+
+    expect(lastDocs.length).toEqual(18)
+  })
+  it('check update miss', async () => {
+    /**
+     * Check what update operation on object (will not match after update) will
+     * trigger live query update and no server update is required.
+     */
+    const { storage } = await prepare()
+
+    let lastDocs: Doc[] = []
+    let opdates = 0
+    await doQuery(storage, { rate: 33 }, (docs) => { lastDocs = docs; opdates++ })
+    expect(lastDocs.length).toEqual(17)
+
+    const op = txBuilder<Task>(taskIds.class.Task).set({ rate: 34 })
+
+    const d = lastDocs[0]
+    await storage.update(txContext(), d._class, d._id, [op])
+
+    expect(opdates).toEqual(1 + 1) // We should have only two updates happening
+
+    expect(lastDocs.length).toEqual(16)
+  })
+  it('check update not fit', async () => {
+    /**
+     * Check what update on object not in query results will not trigger update in case
+     * modify operation is not partially matched.
+     */
+    const { storage, docs: sourceDocs } = await prepare()
+
+    let lastDocs: Doc[] = []
+    let opdates = 0
+    await doQuery(storage, { rate: 33 }, (docs) => { lastDocs = docs; opdates++ })
+    expect(lastDocs.length).toEqual(17)
+
+    const op = txBuilder<Task>(taskIds.class.Task).set({ rate: 34 })
+
+    const d = sourceDocs[1]
+    await storage.update(txContext(), d._class, d._id, [op])
+
+    expect(opdates).toEqual(1) // We should have only two updates happening
+
+    expect(lastDocs.length).toEqual(17)
+  })
+
+  it('check update not fit limit', async () => {
+    /**
+     * Check what update on document( will not match query) in query results with limit will trigger
+     * server update.
+     */
+    const { storage } = await prepare()
+
+    let lastDocs: Doc[] = []
+    let opdates = 0
+    await doQuery(storage, { rate: 33 }, (docs) => { lastDocs = docs; opdates++ }, { limit: 10 })
+    expect(lastDocs.length).toEqual(10)
+
+    const op = txBuilder<Task>(taskIds.class.Task).set({ rate: 34 })
+
+    const d = lastDocs[1]
+    await storage.update(txContext(), d._class, d._id, [op])
+
+    expect(opdates).toEqual(1 + 2) // We have +2 updates, since remove and server update since we have more results.
+
+    expect(lastDocs.length).toEqual(10)
+  })
+  it('check update fit multi query', async () => {
+    /**
+     * Check live query update is working fine with multiple live queries.
+     */
+    const { storage, docs: sourceDocs } = await prepare()
+
+    let lastDocs: Doc[] = []
+    let lastDocs2: Doc[] = []
+    let opdates = 0
+    let opdates2 = 0
+    await doQuery(storage, { rate: 33 }, (docs) => { lastDocs = docs; opdates++ })
+    expect(lastDocs.length).toEqual(17)
+
+    await doQuery(storage, { rate: 34 }, (docs) => { lastDocs2 = docs; opdates2++ })
+    expect(lastDocs2.length).toEqual(1)
+
+    const op = txBuilder<Task>(taskIds.class.Task).set({ rate: 34 })
+
+    const d = sourceDocs[1]
+    await storage.update(txContext(), d._class, d._id, [op])
+
+    expect(opdates).toEqual(1) // We have only 1 updates
+    expect(opdates2).toEqual(1 + 1) // We have only 2 updates
+
+    expect(lastDocs2.length).toEqual(2)
+  })
+  it('check sorting extra request', async () => {
+    /**
+     * Check if sorting has potential effect on results will trigger server update.
+     */
+    const { storage } = await prepare()
+
+    let lastDocs: Doc[] = []
+    let opdates = 0
+    await doQuery(storage, { }, (docs) => { lastDocs = docs; opdates++ }, {
+      limit: 10, sort: { rate: SortingOrder.Ascending }
+    })
+    expect(lastDocs.length).toEqual(10)
+
+    const op = txBuilder<Task>(taskIds.class.Task).set({ rate: 30 })
+
+    const d = lastDocs[1]
+    await storage.update(txContext(), d._class, d._id, [op])
+
+    expect(opdates).toEqual(1 + 2) //
+
+    expect(lastDocs.length).toEqual(10)
+  })
+
+  it('check sorting mainTask request', async () => {
+    /**
+     * Check if sorting has potential effect on results will trigger server update in case of embedded object set.
+     */
+    const { storage } = await prepare()
+
+    let lastDocs: Doc[] = []
+    let opdates = 0
+    await doQuery(storage, { }, (docs) => { lastDocs = docs; opdates++ }, {
+      limit: 10, sort: { mainTask: { rate: SortingOrder.Ascending } }
+    })
+    expect(lastDocs.length).toEqual(10)
+
+    const op = txBuilder<Task>(taskIds.class.Task).mainTask.set({ rate: 30 })
+
+    const d = lastDocs[1]
+    await storage.update(txContext(), d._class, d._id, [op])
+
+    expect(opdates).toEqual(1 + 2) //
+
+    expect(lastDocs.length).toEqual(10)
+  })
+})

--- a/packages/client/src/queries.ts
+++ b/packages/client/src/queries.ts
@@ -50,6 +50,7 @@ interface Query<T extends Doc> {
 
   // A ordered results with some additional flags.
   results: T[]
+  total: number
 
   options?: FindOptions<T>
 }
@@ -67,7 +68,16 @@ export class QueriableStorage implements Domain {
   }
 
   private async refresh<T extends Doc> (query: Query<T>): Promise<void> {
-    const result = await this.find(query._class, query.query, query.options)
+    const findOptions: FindOptions<T> = {
+      ...(query.options ?? {}),
+      countCallback: (skip, limit, total) => {
+        query.total = total
+        if (query.options?.countCallback !== undefined) {
+          query.options?.countCallback(skip, limit, total)
+        }
+      }
+    }
+    const result = await this.find(query._class, query.query, findOptions)
 
     query.results = result
     query.subscriber(result)
@@ -101,48 +111,108 @@ export class QueriableStorage implements Domain {
     }
   }
 
+  findQueryDocument (q: Query<Doc>, _class: Ref<Class<Doc>>, _id: Ref<Doc>): { doc?: Doc, pos: number } {
+    let pos = 0
+    for (const r of q.results) {
+      if (r._id === _id) {
+        return { doc: r, pos: pos }
+      }
+      pos++
+    }
+    return { pos: -1 }
+  }
+
+  /**
+   * Check if query in current state have a potential more results on server not show because of limit.
+   * @param q - query
+   * @returns - true if we need to refresh
+   */
+  checkLimitCapacity (q: Query<Doc>): boolean {
+    if (q.options !== undefined) {
+      const limit = q.options?.limit ?? 0
+      if (limit > 0 && q.results.length < q.total) {
+        // we have more items so try refresh.
+        return true
+      }
+    }
+    return false
+  }
+
   async update (ctx: TxContext, _class: Ref<Class<Doc>>, _id: Ref<Doc>, operations: TxOperation[]): Promise<void> {
     await this.proxy.update(ctx, _class, _id, operations)
 
     for (const q of this.queries.values()) {
       // Find doc, apply update of attributes and check if it is still matches, if not we need to perform request to server after transaction will be complete.
 
-      let needRefresh = true
+      const { doc, pos } = this.findQueryDocument(q, _class, _id)
 
-      // go over documents and check if modification will move object to not matched state.
-      let pos = 0
-      for (const r of q.results) {
-        if (r._id === _id) {
-          if (this.updateResults) {
-            this.model.updateDocument(r, operations)
-          }
-          if (!this.model.matchQuery(q._class, r, q.query)) {
-          // Document is not matched anymore, we need to remove it.
-            q.results.splice(pos, 1)
-          }
-          q.subscriber(q.results)
-          needRefresh = false
-          break
+      let needServerRefresh = false
+      // Perform document update.
+      if (doc != null && this.updateResults) {
+        this.model.updateDocument(doc, operations)
+
+        // If Document is not matched anymore, we need to remove it.
+        if (!this.model.matchQuery(q._class, doc, q.query)) {
+          q.results.splice(pos, 1)
         }
-        pos++
+        // Update subscriber, since we have operation applied, and do not wait for server to perform it's activities.
+        q.subscriber(q.results)
+
+        // If we have limit and total is not our size, we should update from server.
+        if (this.checkLimitCapacity(q)) {
+          needServerRefresh = true
+        }
+        if (this.checkSortingHasEffect(q, operations)) {
+          needServerRefresh = true
+        }
+      } else {
+        // Check for potential operations if we doesn't have object in query results.
+        if (this.checkOperationHasEffect(q, _class, operations) || this.checkSortingHasEffect(q, operations)) {
+          needServerRefresh = true
+        }
       }
-      if (needRefresh && this.model.is(_class, q._class)) {
-        // so we potentially need to fetch new matched objects from server, so do so if class are matching ours.
-        for (const op of operations) {
-          if (op.kind === TxOperationKind.Set) {
-            if (!this.model.isPartialMatched(_class, op._attributes, q.query)) {
-              // We do not match with values updated, so no update is required.
-              needRefresh = false
-            }
-          }
-        }
 
-        if (needRefresh) {
-          await ctx.network
-          await this.refresh(q)
+      if (needServerRefresh) {
+        await ctx.network
+        await this.refresh(q)
+      }
+    }
+  }
+
+  private checkSortingHasEffect (q: Query<Doc>, operations: TxOperation[]): boolean {
+    // Check if object is modified and modification field have influence on sort
+    if (q.options?.sort !== undefined && Object.keys(q.options.sort).length > 0) {
+      // We had sorting defined, we need to refresh query on server.
+
+      for (const op of operations) {
+        if (op.selector !== undefined) {
+          // For embedded objects let's assume we need to refresh
+          return true
+        }
+        if (op.kind === TxOperationKind.Set) {
+          if (this.model.isSortHasEffect(op._attributes, q.options.sort)) {
+            // We do not match with values updated, so no update is required.
+            return true
+          }
         }
       }
     }
+    return false
+  }
+
+  private checkOperationHasEffect (q: Query<Doc>, _class: Ref<Class<Doc>>, operations: TxOperation[]): boolean {
+    if (this.model.is(_class, q._class)) {
+      // so we potentially need to fetch new matched objects from server, so do so if class are matching ours.
+      for (const op of operations) {
+        if (op.kind === TxOperationKind.Set) {
+          if (this.model.isPartialMatched(_class, op._attributes, q.query)) {
+            // We do not match with values updated, so no update is required.
+            return true
+          }
+        }
+      }
+    }
+    return false
   }
 
   async remove (ctx: TxContext, _class: Ref<Class<Doc>>, _id: Ref<Doc>): Promise<void> {
@@ -155,6 +225,16 @@ export class QueriableStorage implements Domain {
         if (r._id === _id) {
           q.results.splice(pos, 1)
           q.subscriber(q.results)
+
+          if (q.options !== undefined) {
+            const limit = q.options?.limit ?? 0
+            if (limit > 0 && q.results.length < q.total) {
+              // We have more elements available, so we need to do refresh.
+              await ctx.network
+              await this.refresh(q)
+            }
+          }
+
           break
         }
         pos++
@@ -180,7 +260,8 @@ export class QueriableStorage implements Domain {
           query,
           subscriber: subscriber as Subscriber<Doc>,
           results: [],
-          options
+          options,
+          total: 0
         }
         q.unsubscriber = () => {
           this.queries.delete(q._id)

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -20,7 +20,7 @@ import {
   CORE_CLASS_MIXIN,
   CORE_CLASS_OBJ, CORE_MIXIN_INDICES, Doc, Mixin, Obj, Property, PropertyType, Ref, Type
 } from './classes'
-import { DocumentQuery, DocumentValue, FindOptions, generateId, RegExpression, Storage, TxContext } from './storage'
+import { DocumentQuery, DocumentSorting, DocumentValue, FindOptions, generateId, RegExpression, Storage, TxContext } from './storage'
 
 export function mixinKey (mixin: Ref<Mixin<Obj>>, key: string): string {
   return key + '|' + mixin.replace('.', '~')
@@ -850,12 +850,12 @@ export class Model implements Storage {
 
   /**
    * Method will check if passed values of object are matched in query.
-   * @param object - partial object values.
+   * @param _attributes - partial object values of operation.
    * @param query - a query.
    */
-  isPartialMatched<T extends Doc> (_class: Ref<Class<Doc>>, object: AnyLayout, query: DocumentQuery<T>): boolean {
+  isPartialMatched<T extends Doc> (_class: Ref<Class<Doc>>, _attributes: AnyLayout, query: DocumentQuery<T>): boolean {
     const stripQuery: AnyLayout = {}
-    const oKeys = new Set<string>(Object.keys(object))
+    const oKeys = new Set<string>(Object.keys(_attributes))
 
     // Make a part of query with values in object.
     let keys = 0
@@ -870,7 +870,26 @@ export class Model implements Storage {
       return false
     }
 
-    return this.matchObject<any>(_class, object, stripQuery)
+    return this.matchObject<any>(_class, _attributes, stripQuery)
+  }
+
+  /**
+   * Check if operation to modify attribute has effect on sorting creteria
+   * @param _attributes
+   * @param sort
+   * @returns
+   */
+  isSortHasEffect<T extends Doc>(_attributes: AnyLayout, sort: DocumentSorting<T>): boolean {
+    const oKeys = new Set<string>(Object.keys(_attributes))
+
+    // Make a part of query with values in object.
+    let keys = 0
+    for (const oe of Object.entries(sort)) {
+      if (oKeys.has(oe[0])) {
+        keys++
+      }
+    }
+    return keys > 0
   }
 
   /**

--- a/packages/domains/src/index.ts
+++ b/packages/domains/src/index.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-import { AnyLayout, Class, DateProperty, Doc, Emb, Mixin, Property, Ref, StringProperty, Tx } from '@anticrm/core'
+import { AnyLayout, Class, DateProperty, Doc, Emb, Mixin, Obj, Property, Ref, StringProperty, Tx } from '@anticrm/core'
 
 // TXes
 
@@ -110,10 +110,13 @@ interface TxOperationBuilder<T> {
   pull: () => TxOperation
 }
 
-export type ArrayElement<A> = A extends Array<infer T> ? T : A
+export type TxBuilderArrayOf<A> = A extends Array<infer T> ? TxBuilderOrOpBuilderOf<T> : never
+
+export type TxBuilderOrOpBuilderOf<A> = A extends Obj ? TxBuilder<A>: TxOperationBuilder<A>
+export type TxBuilderOf<A> = A extends Obj ? TxBuilder<A>: never
 
 export type FieldBuilder<T> = {
-  [P in keyof T]-?: TxOperationBuilder<ArrayElement<T[P]>> & ArrayElement<T[P]>;
+  [P in keyof T]-?: TxBuilderArrayOf<T[P]> | TxBuilderOf<T[P]>;
 }
 export type TxBuilder<T> = TxOperationBuilder<T> & FieldBuilder<T>
 

--- a/plugins/platform-core/jest.config.js
+++ b/plugins/platform-core/jest.config.js
@@ -1,0 +1,12 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  preset: 'ts-jest',
+  coverageDirectory: 'coverage',
+  testEnvironment: 'node',
+  roots: [
+    '<rootDir>/src'
+  ],
+  testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)']
+}


### PR DESCRIPTION
Cover live query cases we interested in.

This PR is depend on #447 So please review only after it, it will be 4+2 files changed.

```
live queries
    ✓ check store op (6 ms)
    ✓ check store limit (2 ms)
    ✓ check remove limit (3 ms)
    ✓ check update fit (3 ms)
    ✓ check update miss (2 ms)
    ✓ check update not fit (2 ms)
    ✓ check update not fit limit (2 ms)
    ✓ check update fit multi query (3 ms)
    ✓ check sorting extra request (1 ms)
    ✓ check sorting mainTask request (2 ms)

------------|---------|----------|---------|---------|------------------------
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s      
------------|---------|----------|---------|---------|------------------------
All files   |   93.62 |    78.08 |   86.67 |   93.62 |                        
 queries.ts |   93.62 |    78.08 |   86.67 |   93.62 | 76,105-106,240,250,267 
------------|---------|----------|---------|---------|------------------------
Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        0.827 s, estimated 3 s
```