### PR TITLE
Move `Resource`, `Metadata` and `Asset` to `status` (`foundation`)

### DIFF
--- a/v0.4/common/changes/@anticrm/platform/resources-to-status_2021-05-11-07-44.json
+++ b/v0.4/common/changes/@anticrm/platform/resources-to-status_2021-05-11-07-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@anticrm/platform",
+      "comment": "`Resource` and `Metadata` now defined in `status` (`foundation`)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@anticrm/platform",
+  "email": "andrey.v.platov@gmail.com"
+}

--- a/v0.4/common/changes/@anticrm/status/resources-to-status_2021-05-11-07-44.json
+++ b/v0.4/common/changes/@anticrm/status/resources-to-status_2021-05-11-07-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@anticrm/status",
+      "comment": "`Resource` and `Metadata` now defined in `status` (`foundation`)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@anticrm/status",
+  "email": "andrey.v.platov@gmail.com"
+}

--- a/v0.4/common/changes/@anticrm/ui/resources-to-status_2021-05-11-07-44.json
+++ b/v0.4/common/changes/@anticrm/ui/resources-to-status_2021-05-11-07-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@anticrm/ui",
+      "comment": "`Asset` now defined in `status` (`foundation`)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@anticrm/ui",
+  "email": "andrey.v.platov@gmail.com"
+}

--- a/v0.4/common/config/rush/pnpm-lock.yaml
+++ b/v0.4/common/config/rush/pnpm-lock.yaml
@@ -9555,6 +9555,14 @@ packages:
       svelte: '>=3.19.0'
     resolution:
       integrity: sha512-SGE7Odznj4dqZtUVIWcoPCvZ9gHImxVIIjrz+O3DDSi0j4OaSLim6MRF4UdhlBKeW3glSRc+tXNSKYvM5x+Dyw==
+  /svelte-hmr/0.12.9_svelte@3.38.2:
+    dependencies:
+      svelte: 3.38.2
+    dev: false
+    peerDependencies:
+      svelte: '>=3.19.0'
+    resolution:
+      integrity: sha512-SGE7Odznj4dqZtUVIWcoPCvZ9gHImxVIIjrz+O3DDSi0j4OaSLim6MRF4UdhlBKeW3glSRc+tXNSKYvM5x+Dyw==
   /svelte-loader/3.1.0:
     dependencies:
       loader-utils: 2.0.0
@@ -9576,14 +9584,26 @@ packages:
       svelte: '>3.0.0'
     resolution:
       integrity: sha512-KOst7tLtYPDXl3q7W1d3kezPapDyNZ/WJZypgKfqplTYS1ia/zdsgJBMnWrOQfec+8W9pInOngsJ8CUF9ejDDA==
-  /svelte-preprocess/4.7.0_755c64f2becf501be7ee6738a692cc1e:
+  /svelte-loader/3.1.0_svelte@3.38.2:
     dependencies:
+      loader-utils: 2.0.0
+      svelte: 3.38.2
+      svelte-dev-helper: 1.1.9
+      svelte-hmr: 0.12.9_svelte@3.38.2
+    dev: false
+    peerDependencies:
+      svelte: '>3.0.0'
+    resolution:
+      integrity: sha512-KOst7tLtYPDXl3q7W1d3kezPapDyNZ/WJZypgKfqplTYS1ia/zdsgJBMnWrOQfec+8W9pInOngsJ8CUF9ejDDA==
+  /svelte-preprocess/4.7.0_136152707eb0640c404be7717d779e53:
+    dependencies:
+      '@babel/core': 7.13.15
       '@types/pug': 2.0.4
       '@types/sass': 1.16.0
       detect-indent: 6.0.0
       sass: 1.32.8
       strip-indent: 3.0.0
-      svelte: 3.37.0
+      svelte: 3.38.2
       typescript: 4.2.4
     dev: false
     engines:
@@ -9627,9 +9647,59 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-iNrY4YGqi0LD2e6oT9YbdSzOKntxk8gmzfqso1z/lUJOZh4o6fyIqkirmiZ8/dDJFqtIE1spVgDFWgkfhLEYlw==
-  /svelte-preprocess/4.7.0_c14a09b624e11ca3eaa9db430b53f206:
+  /svelte-preprocess/4.7.0_1db119eebc53bae9e70b18dfdde1067d:
     dependencies:
-      '@babel/core': 7.13.15
+      '@types/pug': 2.0.4
+      '@types/sass': 1.16.0
+      detect-indent: 6.0.0
+      sass: 1.32.8
+      strip-indent: 3.0.0
+      svelte: 3.38.2
+      typescript: 4.2.4
+    dev: false
+    engines:
+      node: '>= 9.11.2'
+    peerDependencies:
+      '@babel/core': ^7.10.2
+      coffeescript: ^2.5.1
+      less: ^3.11.3
+      node-sass: '*'
+      postcss: ^7 || ^8
+      postcss-load-config: ^2.1.0 || ^3.0.0
+      pug: ^3.0.0
+      sass: ^1.26.8
+      stylus: ^0.54.7
+      sugarss: ^2.0.0
+      svelte: ^3.23.0
+      typescript: ^3.9.5 || ^4.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      coffeescript:
+        optional: true
+      less:
+        optional: true
+      node-sass:
+        optional: true
+      postcss:
+        optional: true
+      postcss-load-config:
+        optional: true
+      pug:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      typescript:
+        optional: true
+    requiresBuild: true
+    resolution:
+      integrity: sha512-iNrY4YGqi0LD2e6oT9YbdSzOKntxk8gmzfqso1z/lUJOZh4o6fyIqkirmiZ8/dDJFqtIE1spVgDFWgkfhLEYlw==
+  /svelte-preprocess/4.7.0_755c64f2becf501be7ee6738a692cc1e:
+    dependencies:
       '@types/pug': 2.0.4
       '@types/sass': 1.16.0
       detect-indent: 6.0.0
@@ -9685,6 +9755,12 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-TRF30F4W4+d+Jr2KzUUL1j8Mrpns/WM/WacxYlo5MMb2E5Qy2Pk1Guj6GylxsW9OnKQl1tnF8q3hG/hQ3h6VUA==
+  /svelte/3.38.2:
+    dev: false
+    engines:
+      node: '>= 8'
+    resolution:
+      integrity: sha512-q5Dq0/QHh4BLJyEVWGe7Cej5NWs040LWjMbicBGZ+3qpFWJ1YObRmUDZKbbovddLC9WW7THTj3kYbTOFmU9fbg==
   /svgo-loader/3.0.0:
     dependencies:
       loader-utils: 1.4.0
@@ -10906,7 +10982,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-Vx0sWwJMhAgXSVA+QTR/GnFkCN/XZuWRfsCV9Wva45NNPLZnX3+G/bnAaNW199rEeRjdxFXyIA3KaAQLDvJSmQ==
+      integrity: sha512-CNAM4cTPYUb2bKQP/RGKG1IeBTuO3+QewyIlxBc0U/898Id1ZcgrmuKJt/nfUaeQmAak0teWQFt3CJ9ITO2q9g==
       tarball: file:projects/domains.tgz
     version: 0.0.0
   file:projects/model.tgz:
@@ -11007,9 +11083,9 @@ packages:
       '@microsoft/api-extractor': 7.13.5
       prettier: 2.2.1
       sass: 1.32.8
-      svelte: 3.37.0
-      svelte-loader: 3.1.0_svelte@3.37.0
-      svelte-preprocess: 4.7.0_755c64f2becf501be7ee6738a692cc1e
+      svelte: 3.38.2
+      svelte-loader: 3.1.0_svelte@3.38.2
+      svelte-preprocess: 4.7.0_1db119eebc53bae9e70b18dfdde1067d
       ts-standard: 10.0.0_982c0164c2c03b5f966b085495de6301
       typescript: 4.2.4
     dev: false
@@ -11112,9 +11188,9 @@ packages:
       prettier: 2.2.1
       sass: 1.32.8
       sass-loader: 11.0.1_sass@1.32.8+webpack@5.32.0
-      svelte: 3.37.0
-      svelte-loader: 3.1.0_svelte@3.37.0
-      svelte-preprocess: 4.7.0_755c64f2becf501be7ee6738a692cc1e
+      svelte: 3.38.2
+      svelte-loader: 3.1.0_svelte@3.38.2
+      svelte-preprocess: 4.7.0_1db119eebc53bae9e70b18dfdde1067d
       ts-standard: 10.0.0_982c0164c2c03b5f966b085495de6301
       typescript: 4.2.4
     dev: false
@@ -11136,6 +11212,7 @@ packages:
       '@types/jest': 26.0.23
       jest: 26.6.3_ts-node@9.1.1
       prettier: 2.2.1
+      svelte: 3.37.0
       ts-standard: 10.0.0_982c0164c2c03b5f966b085495de6301
       typescript: 4.2.4
     dev: false
@@ -11145,7 +11222,7 @@ packages:
       '@typescript-eslint/parser': '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-FJODxkhjRJ13Su+amTkWIvabGjppevZPMqukf/TJAhWCLiCqURfELBsnrHxX2ykmcledd/UHI+p4wcEXvZ/Gng==
+      integrity: sha512-Ex4xui5HuobOhA2kRXH1J3LtQNiWr08rICLjMa6MCc2MqxUTCiKswRnNXRIQb1Pl9RrwnimYKO2OSKFh/Dm6Tw==
       tarball: file:projects/status.tgz
     version: 0.0.0
   file:projects/storage-mongo.tgz_ts-node@9.1.1:
@@ -11224,9 +11301,9 @@ packages:
       jest: 26.6.3_ts-node@9.1.1
       prettier: 2.2.1
       sass: 1.32.8
-      svelte: 3.37.0
-      svelte-loader: 3.1.0_svelte@3.37.0
-      svelte-preprocess: 4.7.0_c14a09b624e11ca3eaa9db430b53f206
+      svelte: 3.38.2
+      svelte-loader: 3.1.0_svelte@3.38.2
+      svelte-preprocess: 4.7.0_136152707eb0640c404be7717d779e53
       ts-standard: 10.0.0_982c0164c2c03b5f966b085495de6301
       typescript: 4.2.4
     dev: false

--- a/v0.4/dev/prod/package.json
+++ b/v0.4/dev/prod/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@anticrm/platform": "~0.4.1",
     "@anticrm/ui": "~0.4.0",
-    "svelte": "~3.37.0",
+    "svelte": "^3.37.0",
     "@anticrm/plugin-login": "~0.4.0",
     "@anticrm/plugin-login-impl": "~0.4.0",
     "@anticrm/plugin-workbench": "~0.4.0",

--- a/v0.4/platform/platform/src/i18n.ts
+++ b/v0.4/platform/platform/src/i18n.ts
@@ -14,12 +14,14 @@
 //
 
 import { Component, Status, Severity, unknownError } from '@anticrm/status'
+import type { IntlString } from '@anticrm/status'
 import { Code } from './status'
 import { setPlatformStatus } from './event'
 
 import { IntlMessageFormat } from 'intl-messageformat'
 
-export type IntlString<T extends Record<string, any> = {}> = string & { __intl_string: T }
+export type { IntlString }
+
 type Loader = (locale: string) => Promise<Record<string, IntlString>>
 
 const locale = 'en'

--- a/v0.4/platform/platform/src/metadata.ts
+++ b/v0.4/platform/platform/src/metadata.ts
@@ -13,14 +13,9 @@
 // limitations under the License.
 //
 
-/**
- * Platform Metadata Identifier (PMI).
- *
- * 'Metadata' is simply any JavaScript object, which is used to configure platform, e.g. IP addresses.
- * Another example of metadata is an asset URL. The logic behind providing asset URLs as metadata is
- * we know URL at compile time only and URLs vary depending on deployment options.
- */
-export type Metadata<T> = string & { __metadata: T }
+import type { Metadata } from '@anticrm/status'
+
+export type { Metadata }
 
 type ExtractType<T, X extends Record<string, Metadata<T>>> = {
   [P in keyof X]: X[P] extends Metadata<infer Z> ? Z : never

--- a/v0.4/platform/platform/src/resource.ts
+++ b/v0.4/platform/platform/src/resource.ts
@@ -14,35 +14,9 @@
 //
 
 import { Plugin, Service, getPlugin } from './plugin'
+import type { Resource } from '@anticrm/status'
 
-/**
- * Platform Resource Identifier (PRI)
- *
- * @remarks
- *
- * Almost anything in the Anticrm Platform is a `Resource`. Resources referenced by Platform Resource Identifier (PRI).
- *
- * TODO: understand Resource better. Is this just a `platform` thing or should be in `core` as well
- *
- * 'Resource' is simply any JavaScript object. There is a plugin exists, which 'resolve' PRI into actual object.
- * This is a difference from Metadata. Metadata object 'resolved' by Platform instance, so we may consider Metadata as
- * a Resource, provided by Platform itself. Because there is always a plugin, which resolve `Resource` resolution is
- * asynchronous process.
- *
- * `Resource` is a string of `kind:plugin.id` format. Since Metadata is a kind of Resource.
- * Metadata also can be resolved using resource API.
- *
- * @example
- * ```typescript
- *   `class:contact.Person` as Resource<Class<Person>> // database object with id === `class:contact.Person`
- *   `string:class.ClassLabel` as Resource<string> // translated string according to current language and i18n settings
- *   `asset:ui.Icons` as Resource<URL> // URL to SVG sprites
- *   `easyscript:2+2` as Resource<() => number> // function
- * ```
- *
- * @public
- */
-export type Resource<T> = string & { __resource: T }
+export type { Resource }
 
 // R E S O U R C E  I N F O
 

--- a/v0.4/platform/status/src/index.ts
+++ b/v0.4/platform/status/src/index.ts
@@ -105,3 +105,50 @@ export function unknownError (err: Error): Status {
   return (err instanceof PlatformError) ? err.status : 
     new Status(Severity.ERROR, Code.UnknownError, { message: err.message })
 }
+
+// R E S O U R C E S
+
+export type IntlString<T extends Record<string, any> = {}> = string & { __intl_string: T }
+
+/**
+ * Platform Metadata Identifier (PMI).
+ *
+ * 'Metadata' is simply any JavaScript object, which is used to configure platform, e.g. IP addresses.
+ * Another example of metadata is an asset URL. The logic behind providing asset URLs as metadata is
+ * we know URL at compile time only and URLs vary depending on deployment options.
+ */
+ export type Metadata<T> = string & { __metadata: T }
+
+ /**
+ * Platform Resource Identifier (PRI)
+ *
+ * @remarks
+ *
+ * Almost anything in the Anticrm Platform is a `Resource`. Resources referenced by Platform Resource Identifier (PRI).
+ *
+ * TODO: understand Resource better. Is this just a `platform` thing or should be in `core` as well
+ *
+ * 'Resource' is simply any JavaScript object. There is a plugin exists, which 'resolve' PRI into actual object.
+ * This is a difference from Metadata. Metadata object 'resolved' by Platform instance, so we may consider Metadata as
+ * a Resource, provided by Platform itself. Because there is always a plugin, which resolve `Resource` resolution is
+ * asynchronous process.
+ *
+ * `Resource` is a string of `kind:plugin.id` format. Since Metadata is a kind of Resource.
+ * Metadata also can be resolved using resource API.
+ *
+ * @example
+ * ```typescript
+ *   `class:contact.Person` as Resource<Class<Person>> // database object with id === `class:contact.Person`
+ *   `string:class.ClassLabel` as Resource<string> // translated string according to current language and i18n settings
+ *   `asset:ui.Icons` as Resource<URL> // URL to SVG sprites
+ *   `easyscript:2+2` as Resource<() => number> // function
+ * ```
+ *
+ * @public
+ */
+export type Resource<T> = string & { __resource: T }
+
+// U I 
+
+type URL = string
+export type Asset = Metadata<URL>

--- a/v0.4/platform/ui/src/types.ts
+++ b/v0.4/platform/ui/src/types.ts
@@ -15,9 +15,9 @@
 
 import { Metadata, Plugin, plugin, Resource, Service } from '@anticrm/platform'
 import { getContext, SvelteComponent } from 'svelte'
+import type { Asset } from '@anticrm/status'
 
-export type URL = string
-export type Asset = Metadata<URL>
+export type { Asset }
 
 /**
  * Describe a browser URI location parsed to path, query and fragment.

--- a/v0.4/plugins/login-impl/package.json
+++ b/v0.4/plugins/login-impl/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@anticrm/platform": "~0.4.1",
-    "svelte": "~3.37.0",
+    "svelte": "^3.37.0",
     "@anticrm/status": "~0.4.0",
     "@anticrm/ui": "~0.4.0",
     "@anticrm/plugin-login": "~0.4.0",

--- a/v0.4/rush.json
+++ b/v0.4/rush.json
@@ -362,7 +362,8 @@
   "projects": [
     {
       "packageName": "@anticrm/status",
-      "projectFolder": "platform/status"
+      "projectFolder": "platform/status",
+      "shouldPublish": true
     },
     {
       "packageName": "@anticrm/platform",
@@ -391,7 +392,8 @@
     },
     {
       "packageName": "@anticrm/ui",
-      "projectFolder": "platform/ui"
+      "projectFolder": "platform/ui",
+      "shouldPublish": true
     },
     {
       "packageName": "@anticrm/sparkling-theme",


### PR DESCRIPTION
We definitely want to use `Resource` in `core` models, so this PR moves `Resource` out of the `platform`. Additionally it moves `Asset` to `status`. This is questionable, and initially we want to avoid UI resources to be in `core` models, but I think to sacrifice this to make models more convenient and provide UI-related information (label and icon) in the core.
