### PR TITLE
100% test coverage for `platform`

### DIFF
--- a/v0.4/platform/platform/src/__tests__/i18n.test.ts
+++ b/v0.4/platform/platform/src/__tests__/i18n.test.ts
@@ -21,8 +21,8 @@ import { addEventListener, PlatformEvent, removeEventListener } from '../event'
 
 const TestComponent = 'test-strings' as Component
 
-const strings =  identify(TestComponent, {
-  loadingPlugin: '' as IntlString<{ plugin: string }>,
+const strings = identify(TestComponent, {
+  loadingPlugin: '' as IntlString<{ plugin: string }>
 })
 
 describe('i18n', () => {

--- a/v0.4/platform/platform/src/__tests__/platform.test.ts
+++ b/v0.4/platform/platform/src/__tests__/platform.test.ts
@@ -18,7 +18,7 @@
 import { Status, Severity, identify, OK, unknownError } from '@anticrm/status'
 
 import { Metadata, getMetadata, loadMetadata, setMetadata } from '../metadata'
-import { Plugin, Service, getPlugin, addLocation } from '../plugin'
+import { Plugin, Service, getPlugin, addLocation, mergeIds } from '../plugin'
 import { Resource, getResource, getResourceInfo, peekResource, setResource } from '../resource'
 import {
   addEventListener,
@@ -37,7 +37,7 @@ import {
   descriptor2,
   plugin3,
   descriptor3,
-  descriptorBad
+  descriptorBad, descriptor4
 } from './shared'
 
 type AnyPlugin = Plugin<Service>
@@ -47,7 +47,6 @@ type ExtractType<T, X extends Record<string, Metadata<T>>> = {
 }
 
 describe('platform', () => {
-
   it('should raise exception for unknown location', async () => {
     const p1 = getPlugin(plugin1)
     return await expect(p1).rejects.toThrowError('plugin1')
@@ -317,5 +316,22 @@ describe('platform', () => {
     const status = unknownError(new Error('something')) as Status<{message: string}>
     expect(status.severity).toBe(Severity.ERROR)
     expect(status.params.message).toBe('something')
+  })
+
+  it('should merge ids', () => {
+    const space = 'anotherSpace'
+    const res1 = mergeIds(descriptor4, { [space]: 'another' })
+    const res2 = mergeIds(descriptor3, { })
+    expect(res1).toEqual({ [space]: `${descriptor4.id}.${space}`, ...descriptor4 })
+    expect(res2).toEqual(descriptor3)
+  })
+
+  it('should throw error when merging same', () => {
+    const space = 'nameSpace'
+    try {
+      mergeIds(descriptor4, { [space]: 'same' })
+    } catch (e) {
+      expect(e).toEqual(new Error(`attempting to overwrite plugin4.${space}`))
+    }
   })
 })

--- a/v0.4/platform/platform/src/__tests__/platform.test.ts
+++ b/v0.4/platform/platform/src/__tests__/platform.test.ts
@@ -328,10 +328,8 @@ describe('platform', () => {
 
   it('should throw error when merging same', () => {
     const space = 'nameSpace'
-    try {
-      mergeIds(descriptor4, { [space]: 'same' })
-    } catch (e) {
-      expect(e).toEqual(new Error(`attempting to overwrite plugin4.${space}`))
-    }
+    expect(descriptor4[space]).toBeDefined()
+    expect(() => mergeIds(descriptor4, { [space]: 'same' }))
+      .toThrowError(new Error(`attempting to overwrite ${descriptor4.id}.${space}`))
   })
 })

--- a/v0.4/platform/platform/src/__tests__/shared.ts
+++ b/v0.4/platform/platform/src/__tests__/shared.ts
@@ -45,6 +45,9 @@ export const descriptor3 = plugin(
   {}
 )
 
+export const plugin4 = 'plugin4' as Plugin<Service>
+export const descriptor4 = plugin(plugin4, {}, { nameSpace: 'any' })
+
 export const plugin3State = {
   parsed: false,
   started: false,

--- a/v0.4/platform/platform/src/index.ts
+++ b/v0.4/platform/platform/src/index.ts
@@ -13,6 +13,9 @@
 // limitations under the License.
 //
 
+import { addStringsLoader } from './i18n'
+import { Platform } from './status'
+
 export * from './metadata'
 export * from './status'
 export * from './event'
@@ -20,12 +23,9 @@ export * from './plugin'
 export * from './resource'
 export * from './i18n'
 
-import { addStringsLoader } from './i18n'
-import { Platform } from './status'
-
 addStringsLoader(Platform, async (lang: string) => {
   switch (lang) {
-    case 'en': return await import(`./lang/en.json`) as any
+    case 'en': return await import('./lang/en.json') as any
   }
   throw new Error('unsupported language')
 })


### PR DESCRIPTION
Closes #512 