### PR TITLE
Fix typos

### DIFF
--- a/docs/content/docs/concepts/architecture.md
+++ b/docs/content/docs/concepts/architecture.md
@@ -5,7 +5,7 @@ menuPosition: 1
 
 # The Platform
 
-Antierp Platform built around a few simple concepts:
+Anticrm Platform built around a few simple concepts:
 
 * `Platform Object` -- a piece of information, typically persisted by the platform in a database. May refer another platform object and `Resource`s
 * `Resource` -- something we can't persist in the database (e.g. JavaScript function, or "mailing service"), but want to refer from a `Platform Object`.

--- a/docs/themes/thxvscode/layouts/partials/connect.html
+++ b/docs/themes/thxvscode/layouts/partials/connect.html
@@ -27,7 +27,7 @@
             </a>
         </li>
         {{- if (not (in .File.Path "apis")) -}}
-        {{- $editUrl := path.Join .Site.Params.Githubrepo "edit/main/docs/content/" .File.Path -}}
+        {{- $editUrl := path.Join .Site.Params.Githubrepo "edit/master/docs/content/" .File.Path -}}
         {{- $editUrl = delimit (slice "https://github.com/" $editUrl) "" -}}
         <li id="connect-editpage">
             <a href="{{$editUrl}}" target="_blank">

--- a/docs/themes/thxvscode/layouts/partials/footer.html
+++ b/docs/themes/thxvscode/layouts/partials/footer.html
@@ -28,7 +28,7 @@
                             href="https://www.microsoft.com/en-us/legal/intellectualproperty/copyright/default.aspx"
                             target="_blank">Terms of Use</a></li>
                     <li><a id="footer-license-link"
-                            href="https://github.com/{{.Site.Params.githubRepo}}/blob/main/LICENSE">License</a>
+                            href="https://github.com/{{.Site.Params.githubRepo}}/blob/master/docs/themes/thxvscode/LICENSE">License</a>
                     </li>
                 </ul>
                 <div class="copyright">


### PR DESCRIPTION
There were a few issues related to the outdated documentation:
* the license and the edit buttons were using the main branch, it looks like it was replaced.
* typo in architecture.md file where Anticrm was written as Antierp.